### PR TITLE
Replace ObjectAnimator with Transitions API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:3.2.0'
+    classpath 'com.android.tools.build:gradle:3.4.0-rc03'
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$versions.kotlin"
   }
 }

--- a/fluidresizelayout/build.gradle
+++ b/fluidresizelayout/build.gradle
@@ -30,5 +30,5 @@ android {
 
 dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$versions.kotlin"
-  implementation "androidx.constraintlayout:constraintlayout:1.1.3"
+  implementation "androidx.constraintlayout:constraintlayout:2.0.0-alpha3"
 }

--- a/fluidresizelayout/build.gradle
+++ b/fluidresizelayout/build.gradle
@@ -30,4 +30,5 @@ android {
 
 dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$versions.kotlin"
+  implementation "androidx.constraintlayout:constraintlayout:1.1.3"
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -35,7 +35,7 @@ dependencies {
   implementation project(path: ':fluidresizelayout')
 
   implementation "androidx.appcompat:appcompat:$versions.androidx"
-  implementation "androidx.constraintlayout:constraintlayout:1.1.3"
+  implementation "androidx.constraintlayout:constraintlayout:2.0.0-alpha3"
 
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$versions.kotlin"
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -35,14 +35,16 @@ dependencies {
   implementation project(path: ':fluidresizelayout')
 
   implementation "androidx.appcompat:appcompat:$versions.androidx"
+  implementation "androidx.constraintlayout:constraintlayout:1.1.3"
+
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$versions.kotlin"
 
   implementation "com.jakewharton.timber:timber:$versions.timber"
   implementation('com.github.JakeWharton:kotterknife:e157638df1') {
     exclude group: 'com.android.support'
   }
-  implementation 'io.reactivex.rxjava2:rxjava:2.1.9'
-  implementation 'io.reactivex.rxjava2:rxandroid:2.0.1'
+  implementation 'io.reactivex.rxjava2:rxjava:2.2.2'
+  implementation 'io.reactivex.rxjava2:rxandroid:2.0.2'
   implementation "com.jakewharton.rxbinding2:rxbinding:$versions.rxBindings"
   implementation "com.jakewharton.rxrelay2:rxrelay:2.0.0"
   implementation 'io.reactivex.rxjava2:rxkotlin:2.2.0'

--- a/sample/src/main/java/me/saket/fluidresize/sample/FluidResizeActivity.kt
+++ b/sample/src/main/java/me/saket/fluidresize/sample/FluidResizeActivity.kt
@@ -2,6 +2,9 @@ package me.saket.fluidresize.sample
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import kotlinx.android.synthetic.main.activity_fluid_resize.*
+import me.saket.fluidresize.ActivityViewHolder
+import me.saket.fluidresize.KeyboardVisibilityDetector
 import me.saket.fluidresize.R
 
 class FluidResizeActivity : AppCompatActivity() {
@@ -10,6 +13,20 @@ class FluidResizeActivity : AppCompatActivity() {
     super.onCreate(savedInstanceState)
     setContentView(R.layout.activity_fluid_resize)
 
-    FluidContentResizer.listen(this)
+    val viewHolder = ActivityViewHolder.createFrom(this)
+
+    KeyboardVisibilityDetector.listen(viewHolder) {
+      event ->
+        if (event.contentHeight <= event.contentHeightBeforeResize) {
+            next_button.alpha = 0f
+        } else {
+            next_button.animate()
+                    .alpha(1f)
+                    .setStartDelay(150)
+                    .start()
+        }
+    }
+
+      FluidContentResizer.listen(this)
   }
 }

--- a/sample/src/main/res/layout/activity_fluid_resize.xml
+++ b/sample/src/main/res/layout/activity_fluid_resize.xml
@@ -1,14 +1,40 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:tools="http://schemas.android.com/tools"
-  android:layout_width="match_parent"
-  android:layout_height="match_parent"
-  android:orientation="vertical">
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:orientation="vertical">
 
-  <EditText
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:layout_gravity="center"
-    android:text="Sup world?"
-    tools:ignore="HardcodedText" />
-</FrameLayout>
+    <EditText
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        android:layout_gravity="center"
+        android:text="Sup world?"
+        tools:ignore="HardcodedText,LabelFor,UnusedAttribute"
+        android:importantForAutofill="no"
+        android:inputType="text" />
+
+    <TextView
+        android:id="@+id/next_button"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        android:text="Next"
+        android:textAllCaps="true"
+        android:paddingTop="18dp"
+        android:paddingBottom="18dp"
+        android:textSize="20sp"
+        android:textStyle="bold"
+        android:textAlignment="center"
+        android:background="@android:color/holo_green_light"
+        android:textColor="@android:color/white"
+        />
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Let me know if you like this or would prefer something different, happy to modify. And THANK YOU for the super nice project, it was a joy to experiment with.

It seems that setting the height on the view's `LayoutParams` was what was holding up the TransitionsManager from detecting the *original* state of the content view, but we also don't know the bounds on the first pass - adding a `post(Runnable)` allows us to get the proper original height right after the first layout pass.