### PR TITLE
Remove animator update listeners on root view detach

### DIFF
--- a/sample/src/main/java/me/saket/fluidresize/sample/FluidContentResizer.kt
+++ b/sample/src/main/java/me/saket/fluidresize/sample/FluidContentResizer.kt
@@ -21,6 +21,7 @@ object FluidContentResizer {
     }
     viewHolder.onDetach {
       heightAnimator.cancel()
+      heightAnimator.removeAllUpdateListeners()
     }
   }
 


### PR DESCRIPTION
Theres a leak in the sample app. The Animator.updateListener holds a reference to the Activity's contentView. When we detach the View we just cancel the animation, we dont remove the listeners, so we keep a reference to the Activity. 

This fixes that by calling removeAllUpdateListeners in viewHolder.OnDetach